### PR TITLE
feat: 새로운 SPA 프론트엔드 추가 및 프로젝트 문서 구조 정리

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,27 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+node_modules/
+pnpm-lock.yaml
+.vscode/

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,5 @@
+# Vue 3 + TypeScript + Vite
+
+This template should help get you started developing with Vue 3 and TypeScript in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+
+Learn more about the recommended Project Setup and IDE Support in the [Vue Docs TypeScript Guide](https://vuejs.org/guide/typescript/overview.html#project-setup).

--- a/frontend/env.d.ts
+++ b/frontend/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PaperLens AI</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+ "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc && vite build",
+    "preview": "vite preview",
+    "type-check": "vue-tsc --noEmit"
+  },
+  "dependencies": {
+    "vue": "^3.5.13",
+    "vue-router": "^4.4.5",
+    "pinia": "^2.2.6",
+    "axios": "^1.7.9",
+    "pdfjs-dist": "^4.9.155",
+    "@vueuse/core": "^11.3.0",
+    "chart.js": "^4.4.7",
+    "vue-chartjs": "^5.3.2",
+    "lucide-vue-next": "^0.468.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.2.1",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.5",
+    "vue-tsc": "^2.2.0",
+    "@types/node": "^22.10.2",
+    "tailwindcss": "^3.4.17",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49"
+  },
+  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,6 @@
+<template>
+  <router-view />
+</template>
+
+<script setup lang="ts">
+</script>

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1,0 +1,39 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  html {
+    font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+  body {
+    @apply bg-surface-50 text-slate-800 antialiased;
+    background-image:
+      radial-gradient(circle at 0% 0%, rgba(37, 99, 235, 0.06), transparent 55%),
+      radial-gradient(circle at 100% 100%, rgba(148, 163, 184, 0.22), transparent 55%);
+    background-attachment: fixed;
+  }
+}
+
+@layer components {
+  .btn-primary {
+    @apply inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg
+           hover:bg-primary-700 active:bg-primary-800 transition-all font-medium text-sm
+           shadow-sm hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed;
+  }
+  .btn-secondary {
+    @apply inline-flex items-center gap-2 px-4 py-2 bg-white text-slate-700 border border-slate-200
+           rounded-lg hover:bg-surface-50 transition-all font-medium text-sm shadow-sm/50;
+  }
+  .input {
+    @apply w-full px-3 py-2 border border-slate-200 rounded-lg text-sm
+           focus:outline-none focus:ring-2 focus:ring-primary-500/70 focus:border-transparent
+           placeholder:text-slate-400 bg-white shadow-xs;
+  }
+  .card {
+    @apply bg-white/80 backdrop-blur-sm rounded-2xl border border-slate-200/80 shadow-sm;
+  }
+  .card-elevated {
+    @apply transition-all duration-200 hover:shadow-lg hover:-translate-y-0.5;
+  }
+}

--- a/frontend/src/components/admin/StatCard.vue
+++ b/frontend/src/components/admin/StatCard.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="card p-4">
+    <p class="text-xs font-medium text-slate-500 mb-1">{{ title }}</p>
+    <p class="text-2xl font-bold text-slate-800">{{ value.toLocaleString() }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ title: string; value: number; icon?: string; color?: string }>()
+</script>

--- a/frontend/src/components/ai/QaPanel.vue
+++ b/frontend/src/components/ai/QaPanel.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="flex flex-col h-full">
+    <div ref="messagesEl" class="flex-1 overflow-y-auto p-4 space-y-4">
+      <div v-if="messages.length === 0" class="text-center py-8">
+        <MessageSquare class="w-10 h-10 text-slate-200 mx-auto mb-2" />
+        <p class="text-sm text-slate-400">이 문서에 대해 질문해보세요</p>
+        <div class="mt-4 space-y-1">
+          <button
+            v-for="q in suggestedQuestions"
+            :key="q"
+            @click="sendQuestion(q)"
+            class="block w-full text-left text-xs px-3 py-2 bg-surface-50 hover:bg-primary-50 text-slate-600 hover:text-primary-700 rounded-lg transition-colors"
+          >
+            {{ q }}
+          </button>
+        </div>
+      </div>
+
+      <div v-for="(msg, i) in messages" :key="i">
+        <div class="flex justify-end">
+          <div class="max-w-[80%] px-3 py-2 bg-primary-600 text-white rounded-xl rounded-tr-sm text-sm">
+            {{ msg.question }}
+          </div>
+        </div>
+        <div class="flex justify-start mt-2">
+          <div class="max-w-[90%] space-y-2">
+            <div class="px-3 py-2 bg-surface-100 text-slate-700 rounded-xl rounded-tl-sm text-sm leading-relaxed">
+              <Loader2 v-if="msg.loading" class="w-4 h-4 animate-spin text-slate-400" />
+              <span v-else>{{ msg.answer }}</span>
+            </div>
+            <div v-if="msg.sources && msg.sources.length > 0" class="px-3">
+              <p class="text-xs text-slate-400 mb-1">출처</p>
+              <div class="flex flex-wrap gap-1">
+                <span
+                  v-for="src in msg.sources"
+                  :key="src.chunkId"
+                  class="px-2 py-0.5 bg-white border border-slate-200 text-slate-500 rounded text-xs"
+                >
+                  p.{{ src.pageFrom }}-{{ src.pageTo }}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="p-4 border-t border-slate-100">
+      <div class="flex gap-2">
+        <input
+          v-model="input"
+          @keydown.enter.prevent="sendQuestion(input)"
+          type="text"
+          class="input flex-1 text-sm"
+          placeholder="질문을 입력하세요..."
+          :disabled="isLoading"
+        />
+        <button
+          @click="sendQuestion(input)"
+          :disabled="!input.trim() || isLoading"
+          class="btn-primary px-3"
+        >
+          <Send class="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, nextTick } from 'vue'
+import { MessageSquare, Send, Loader2 } from 'lucide-vue-next'
+import { api } from '@/lib/api'
+import type { QaResponse, ChunkSource } from '@/types'
+
+const props = defineProps<{ documentId: number }>()
+
+interface Message {
+  question: string
+  answer: string
+  loading: boolean
+  sources: ChunkSource[]
+}
+
+const messages = ref<Message[]>([])
+const input = ref('')
+const isLoading = ref(false)
+const messagesEl = ref<HTMLElement>()
+
+const suggestedQuestions = [
+  '이 문서의 핵심 내용을 요약해주세요.',
+  '주요 조항이나 규정이 있나요?',
+  '중요한 날짜나 기한이 있나요?',
+]
+
+async function sendQuestion(question: string) {
+  if (!question.trim() || isLoading.value) return
+  input.value = ''
+  isLoading.value = true
+
+  const msg: Message = { question, answer: '', loading: true, sources: [] }
+  messages.value.push(msg)
+  await nextTick()
+  messagesEl.value?.scrollTo({ top: messagesEl.value.scrollHeight, behavior: 'smooth' })
+
+  try {
+    const res = await api.post<QaResponse>('/ai/qa', {
+      question,
+      documentId: props.documentId
+    })
+    msg.answer = res.data.answer
+    msg.sources = res.data.sources
+  } catch {
+    msg.answer = '답변을 생성하는 중 오류가 발생했습니다.'
+  } finally {
+    msg.loading = false
+    isLoading.value = false
+    await nextTick()
+    messagesEl.value?.scrollTo({ top: messagesEl.value.scrollHeight, behavior: 'smooth' })
+  }
+}
+</script>

--- a/frontend/src/components/ai/SimilarDocuments.vue
+++ b/frontend/src/components/ai/SimilarDocuments.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="space-y-3">
+    <div v-if="loading" class="flex justify-center py-8">
+      <Loader2 class="w-6 h-6 animate-spin text-slate-300" />
+    </div>
+    <div v-else-if="documents.length === 0" class="text-center py-8 text-sm text-slate-400">
+      유사한 문서가 없습니다.
+    </div>
+    <RouterLink
+      v-else
+      v-for="doc in documents"
+      :key="doc.documentId"
+      :to="`/documents/${doc.documentId}`"
+      class="block p-3 border border-slate-100 rounded-lg hover:border-primary-200 hover:bg-primary-50 transition-colors"
+    >
+      <div class="flex items-start justify-between gap-2">
+        <p class="text-sm font-medium text-slate-700 line-clamp-1">{{ doc.title }}</p>
+        <span class="text-xs text-primary-600 bg-primary-50 px-1.5 py-0.5 rounded flex-shrink-0">
+          {{ Math.round(doc.similarity * 100) }}%
+        </span>
+      </div>
+      <p v-if="doc.summaryShort" class="text-xs text-slate-500 mt-1 line-clamp-2">{{ doc.summaryShort }}</p>
+    </RouterLink>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { Loader2 } from 'lucide-vue-next'
+import { api } from '@/lib/api'
+import type { SimilarDocument } from '@/types'
+
+const props = defineProps<{ documentId: number }>()
+const documents = ref<SimilarDocument[]>([])
+const loading = ref(false)
+
+onMounted(async () => {
+  loading.value = true
+  try {
+    const res = await api.get<SimilarDocument[]>(`/ai/similar/${props.documentId}`)
+    documents.value = res.data
+  } finally {
+    loading.value = false
+  }
+})
+</script>

--- a/frontend/src/components/common/StatusBadge.vue
+++ b/frontend/src/components/common/StatusBadge.vue
@@ -1,0 +1,21 @@
+<template>
+  <span :class="badgeClass" class="px-1.5 py-0.5 rounded text-xs font-medium">
+    {{ label }}
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ status: string }>()
+
+const config: Record<string, { label: string; class: string }> = {
+  PENDING:    { label: '대기', class: 'bg-yellow-50 text-yellow-700' },
+  PROCESSING: { label: '처리중', class: 'bg-blue-50 text-blue-700' },
+  INDEXED:    { label: '완료', class: 'bg-green-50 text-green-700' },
+  FAILED:     { label: '실패', class: 'bg-red-50 text-red-700' },
+}
+
+const badgeClass = computed(() => config[props.status]?.class || 'bg-slate-100 text-slate-600')
+const label = computed(() => config[props.status]?.label || props.status)
+</script>

--- a/frontend/src/components/document/DocumentCard.vue
+++ b/frontend/src/components/document/DocumentCard.vue
@@ -1,0 +1,68 @@
+<template>
+  <div
+    class="card card-elevated p-4 cursor-pointer hover:border-primary-200 group"
+    @click="$emit('click')"
+  >
+    <div class="flex items-start justify-between mb-3">
+      <div class="flex items-center gap-2 min-w-0">
+        <div class="w-8 h-8 bg-red-100 rounded-lg flex items-center justify-center flex-shrink-0">
+          <FileText class="w-4 h-4 text-red-600" />
+        </div>
+        <div class="min-w-0">
+          <h3 class="text-sm font-semibold text-slate-800 truncate group-hover:text-primary-700">
+            {{ document.title }}
+          </h3>
+          <p class="text-xs text-slate-400 truncate">{{ document.originalFileName }}</p>
+        </div>
+      </div>
+      <div class="flex items-center gap-1 flex-shrink-0 ml-2">
+        <StatusBadge :status="document.status" />
+        <button
+          @click.stop="$emit('delete')"
+          class="opacity-0 group-hover:opacity-100 p-1 hover:bg-red-50 rounded transition-all"
+        >
+          <Trash2 class="w-3.5 h-3.5 text-red-400" />
+        </button>
+      </div>
+    </div>
+
+    <p v-if="document.summaryShort" class="text-xs text-slate-500 line-clamp-2 mb-3 leading-relaxed">
+      {{ document.summaryShort }}
+    </p>
+    <p v-else-if="document.description" class="text-xs text-slate-500 line-clamp-2 mb-3">
+      {{ document.description }}
+    </p>
+
+    <div class="flex items-center justify-between text-xs text-slate-400">
+      <div class="flex items-center gap-3">
+        <span>{{ document.pageCount }}p</span>
+        <span v-if="document.documentType" class="px-1.5 py-0.5 bg-surface-100 text-slate-500 rounded">
+          {{ document.documentType }}
+        </span>
+      </div>
+      <span>{{ formatDate(document.createdAt) }}</span>
+    </div>
+
+    <div v-if="document.tags.length > 0" class="flex flex-wrap gap-1 mt-2">
+      <span
+        v-for="tag in document.tags.slice(0, 3)"
+        :key="tag"
+        class="px-1.5 py-0.5 bg-primary-50 text-primary-600 rounded text-xs"
+      >{{ tag }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { FileText, Trash2 } from 'lucide-vue-next'
+import type { Document } from '@/types'
+import StatusBadge from '@/components/common/StatusBadge.vue'
+
+defineProps<{ document: Document }>()
+defineEmits<{ click: []; delete: [] }>()
+
+function formatDate(dateStr: string): string {
+  if (!dateStr) return ''
+  return new Date(dateStr).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })
+}
+</script>

--- a/frontend/src/components/document/UploadModal.vue
+++ b/frontend/src/components/document/UploadModal.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40" @click.self="$emit('close')">
+    <div class="card w-full max-w-lg p-6 mx-4">
+      <div class="flex items-center justify-between mb-6">
+        <h2 class="text-lg font-bold text-slate-800">PDF 업로드</h2>
+        <button @click="$emit('close')" class="p-1 hover:bg-surface-100 rounded">
+          <X class="w-5 h-5 text-slate-400" />
+        </button>
+      </div>
+
+      <form @submit.prevent="handleUpload" class="space-y-4">
+        <div
+          @dragover.prevent
+          @drop.prevent="handleDrop"
+          @click="fileInput?.click()"
+          :class="[
+            'border-2 border-dashed rounded-xl p-8 text-center cursor-pointer transition-colors',
+            file ? 'border-primary-300 bg-primary-50' : 'border-slate-200 hover:border-primary-300 hover:bg-surface-50'
+          ]"
+        >
+          <input ref="fileInput" type="file" accept=".pdf" class="hidden" @change="handleFileChange" />
+          <FileText class="w-10 h-10 text-slate-300 mx-auto mb-2" />
+          <p v-if="file" class="text-sm font-medium text-primary-700">{{ file.name }}</p>
+          <p v-else class="text-sm text-slate-500">
+            PDF 파일을 드래그하거나 클릭하여 선택
+          </p>
+          <p class="text-xs text-slate-400 mt-1">최대 100MB</p>
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium text-slate-700 mb-1">제목 <span class="text-red-500">*</span></label>
+          <input v-model="title" type="text" class="input" placeholder="문서 제목" required />
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium text-slate-700 mb-1">설명</label>
+          <textarea v-model="description" class="input resize-none" rows="2" placeholder="문서 설명 (선택)" />
+        </div>
+
+        <div v-if="uploading" class="space-y-1">
+          <div class="flex justify-between text-xs text-slate-500">
+            <span>업로드 중...</span>
+            <span>{{ progress }}%</span>
+          </div>
+          <div class="h-1.5 bg-surface-200 rounded-full overflow-hidden">
+            <div class="h-full bg-primary-500 transition-all" :style="{ width: `${progress}%` }" />
+          </div>
+        </div>
+
+        <div v-if="error" class="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">{{ error }}</div>
+
+        <div class="flex gap-3 justify-end">
+          <button type="button" @click="$emit('close')" class="btn-secondary">취소</button>
+          <button type="submit" class="btn-primary" :disabled="!file || !title || uploading">
+            <Loader2 v-if="uploading" class="w-4 h-4 animate-spin" />
+            {{ uploading ? '업로드 중...' : '업로드' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { FileText, X, Loader2 } from 'lucide-vue-next'
+import { useDocumentStore } from '@/stores/document'
+
+const emit = defineEmits<{ close: []; success: [] }>()
+const store = useDocumentStore()
+
+const fileInput = ref<HTMLInputElement>()
+const file = ref<File | null>(null)
+const title = ref('')
+const description = ref('')
+const uploading = ref(false)
+const progress = ref(0)
+const error = ref('')
+
+function handleFileChange(e: Event) {
+  const f = (e.target as HTMLInputElement).files?.[0]
+  if (f) { file.value = f; if (!title.value) title.value = f.name.replace('.pdf', '') }
+}
+
+function handleDrop(e: DragEvent) {
+  const f = e.dataTransfer?.files[0]
+  if (f?.type === 'application/pdf') { file.value = f; if (!title.value) title.value = f.name.replace('.pdf', '') }
+}
+
+async function handleUpload() {
+  if (!file.value) return
+  uploading.value = true
+  error.value = ''
+  progress.value = 10
+
+  try {
+    const formData = new FormData()
+    formData.append('file', file.value)
+    formData.append('title', title.value)
+    if (description.value) formData.append('description', description.value)
+
+    progress.value = 50
+    await store.uploadDocument(formData)
+    progress.value = 100
+    emit('success')
+  } catch {
+    error.value = '업로드에 실패했습니다. 다시 시도해주세요.'
+  } finally {
+    uploading.value = false
+  }
+}
+</script>

--- a/frontend/src/components/viewer/PdfViewer.vue
+++ b/frontend/src/components/viewer/PdfViewer.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="flex flex-col h-full bg-slate-700">
+    <div class="flex items-center justify-between px-4 py-2 bg-slate-800 text-white">
+      <div class="flex items-center gap-2">
+        <button @click="prevPage" :disabled="currentPage <= 1" class="p-1 hover:bg-slate-700 rounded disabled:opacity-30">
+          <ChevronLeft class="w-4 h-4" />
+        </button>
+        <span class="text-sm">{{ currentPage }} / {{ totalPages }}</span>
+        <button @click="nextPage" :disabled="currentPage >= totalPages" class="p-1 hover:bg-slate-700 rounded disabled:opacity-30">
+          <ChevronRight class="w-4 h-4" />
+        </button>
+      </div>
+      <div class="flex items-center gap-2">
+        <button @click="zoomOut" class="p-1 hover:bg-slate-700 rounded">
+          <ZoomOut class="w-4 h-4" />
+        </button>
+        <span class="text-xs w-12 text-center">{{ Math.round(scale * 100) }}%</span>
+        <button @click="zoomIn" class="p-1 hover:bg-slate-700 rounded">
+          <ZoomIn class="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+
+    <div class="flex-1 overflow-auto flex justify-center p-4">
+      <div v-if="loading" class="flex items-center justify-center w-full">
+        <Loader2 class="w-8 h-8 animate-spin text-white" />
+      </div>
+      <canvas v-else ref="canvasRef" class="shadow-2xl" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue'
+import { ChevronLeft, ChevronRight, ZoomIn, ZoomOut, Loader2 } from 'lucide-vue-next'
+
+const props = defineProps<{ documentId: number }>()
+
+const canvasRef = ref<HTMLCanvasElement>()
+const currentPage = ref(1)
+const totalPages = ref(0)
+const scale = ref(1.2)
+const loading = ref(true)
+
+let pdfDoc: any = null
+
+async function loadPdf() {
+  loading.value = true
+  try {
+    const pdfjsLib = await import('pdfjs-dist')
+    pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
+      'pdfjs-dist/build/pdf.worker.mjs',
+      import.meta.url
+    ).toString()
+
+    const url = `/api/viewer/${props.documentId}/stream`
+    pdfDoc = await pdfjsLib.getDocument(url).promise
+    totalPages.value = pdfDoc.numPages
+    await renderPage(1)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function renderPage(num: number) {
+  if (!pdfDoc || !canvasRef.value) return
+  const page = await pdfDoc.getPage(num)
+  const viewport = page.getViewport({ scale: scale.value })
+  const canvas = canvasRef.value
+  canvas.width = viewport.width
+  canvas.height = viewport.height
+  const ctx = canvas.getContext('2d')!
+  await page.render({ canvasContext: ctx, viewport }).promise
+  currentPage.value = num
+}
+
+function prevPage() { if (currentPage.value > 1) renderPage(currentPage.value - 1) }
+function nextPage() { if (currentPage.value < totalPages.value) renderPage(currentPage.value + 1) }
+function zoomIn() { scale.value = Math.min(scale.value + 0.2, 3.0); renderPage(currentPage.value) }
+function zoomOut() { scale.value = Math.max(scale.value - 0.2, 0.5); renderPage(currentPage.value) }
+
+onMounted(loadPdf)
+watch(() => props.documentId, loadPdf)
+</script>

--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="min-h-screen flex flex-col">
+    <header class="bg-white border-b border-slate-200 sticky top-0 z-40">
+      <div class="max-w-7xl mx-auto px-4 h-14 flex items-center justify-between">
+        <RouterLink to="/" class="flex items-center gap-2 font-bold text-lg text-primary-600">
+          <FileText class="w-5 h-5" />
+          PaperLens AI
+        </RouterLink>
+
+        <nav class="flex items-center gap-1">
+          <RouterLink
+            to="/"
+            class="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors"
+            :class="$route.name === 'documents' ? 'bg-primary-50 text-primary-700' : 'text-slate-600 hover:bg-surface-100'"
+          >
+            문서
+          </RouterLink>
+          <RouterLink
+            v-if="auth.isAdmin"
+            to="/admin"
+            class="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors"
+            :class="$route.name === 'admin' ? 'bg-primary-50 text-primary-700' : 'text-slate-600 hover:bg-surface-100'"
+          >
+            관리자
+          </RouterLink>
+        </nav>
+
+        <div class="flex items-center gap-3">
+          <span class="text-sm text-slate-600">{{ auth.user?.name }}</span>
+          <button @click="handleLogout" class="btn-secondary text-xs px-3 py-1.5">
+            로그아웃
+          </button>
+        </div>
+      </div>
+    </header>
+
+    <main class="flex-1">
+      <RouterView />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { FileText } from 'lucide-vue-next'
+import { useAuthStore } from '@/stores/auth'
+import { useRouter } from 'vue-router'
+
+const auth = useAuthStore()
+const router = useRouter()
+
+function handleLogout() {
+  auth.logout()
+  router.push('/login')
+}
+</script>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,18 @@
+import axios from 'axios'
+import router from '@/router'
+
+export const api = axios.create({
+  baseURL: '/api',
+  timeout: 30000,
+})
+
+api.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    if (err.response?.status === 401) {
+      localStorage.removeItem('token')
+      router.push('/login')
+    }
+    return Promise.reject(err)
+  }
+)

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,10 @@
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import App from './App.vue'
+import router from './router'
+import './assets/main.css'
+
+const app = createApp(App)
+app.use(createPinia())
+app.use(router)
+app.mount('#app')

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,0 +1,48 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    {
+      path: '/login',
+      name: 'login',
+      component: () => import('@/views/LoginView.vue'),
+      meta: { public: true }
+    },
+    {
+      path: '/',
+      component: () => import('@/layouts/AppLayout.vue'),
+      children: [
+        {
+          path: '',
+          name: 'documents',
+          component: () => import('@/views/DocumentListView.vue')
+        },
+        {
+          path: 'documents/:id',
+          name: 'document-detail',
+          component: () => import('@/views/DocumentDetailView.vue')
+        },
+        {
+          path: 'admin',
+          name: 'admin',
+          component: () => import('@/views/AdminView.vue'),
+          meta: { adminOnly: true }
+        }
+      ]
+    },
+  ]
+})
+
+router.beforeEach((to) => {
+  const auth = useAuthStore()
+  if (!to.meta.public && !auth.token) {
+    return { name: 'login' }
+  }
+  if (to.meta.adminOnly && auth.user?.role !== 'ADMIN') {
+    return { name: 'documents' }
+  }
+})
+
+export default router

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,0 +1,35 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { api } from '@/lib/api'
+import type { User } from '@/types'
+
+export const useAuthStore = defineStore('auth', () => {
+  const token = ref<string | null>(localStorage.getItem('token'))
+  const user = ref<User | null>(JSON.parse(localStorage.getItem('user') || 'null'))
+
+  const isAuthenticated = computed(() => !!token.value)
+  const isAdmin = computed(() => user.value?.role === 'ADMIN')
+
+  async function login(email: string, password: string) {
+    const res = await api.post('/auth/login', { email, password })
+    token.value = res.data.token
+    user.value = { email: res.data.email, name: res.data.name, role: res.data.role }
+    localStorage.setItem('token', res.data.token)
+    localStorage.setItem('user', JSON.stringify(user.value))
+    api.defaults.headers.common['Authorization'] = `Bearer ${res.data.token}`
+  }
+
+  function logout() {
+    token.value = null
+    user.value = null
+    localStorage.removeItem('token')
+    localStorage.removeItem('user')
+    delete api.defaults.headers.common['Authorization']
+  }
+
+  if (token.value) {
+    api.defaults.headers.common['Authorization'] = `Bearer ${token.value}`
+  }
+
+  return { token, user, isAuthenticated, isAdmin, login, logout }
+})

--- a/frontend/src/stores/document.ts
+++ b/frontend/src/stores/document.ts
@@ -1,0 +1,64 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { api } from '@/lib/api'
+import type { Document, DocumentDetail, PageResponse } from '@/types'
+
+export const useDocumentStore = defineStore('document', () => {
+  const documents = ref<Document[]>([])
+  const currentDocument = ref<DocumentDetail | null>(null)
+  const loading = ref(false)
+  const total = ref(0)
+  const totalPages = ref(0)
+
+  async function fetchDocuments(params: {
+    keyword?: string
+    docType?: string
+    page?: number
+    size?: number
+  } = {}) {
+    loading.value = true
+    try {
+      const res = await api.get<PageResponse<Document>>('/documents', { params })
+      documents.value = res.data.content
+      total.value = res.data.totalElements
+      totalPages.value = res.data.totalPages
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function fetchDocument(id: number) {
+    loading.value = true
+    try {
+      const res = await api.get<DocumentDetail>(`/documents/${id}`)
+      currentDocument.value = res.data
+      return res.data
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function uploadDocument(formData: FormData) {
+    const res = await api.post<Document>('/documents/upload', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+    await fetchDocuments()
+    return res.data
+  }
+
+  async function deleteDocument(id: number) {
+    await api.delete(`/documents/${id}`)
+    documents.value = documents.value.filter(d => d.id !== id)
+  }
+
+  async function updateDocument(id: number, data: { title?: string; description?: string; tags?: string[] }) {
+    const res = await api.patch<DocumentDetail>(`/documents/${id}`, data)
+    currentDocument.value = res.data
+    return res.data
+  }
+
+  return {
+    documents, currentDocument, loading, total, totalPages,
+    fetchDocuments, fetchDocument, uploadDocument, deleteDocument, updateDocument
+  }
+})

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,77 @@
+export interface User {
+  email: string
+  name: string
+  role: 'USER' | 'ADMIN'
+}
+
+export interface Document {
+  id: number
+  title: string
+  description: string | null
+  originalFileName: string
+  pageCount: number
+  fileSize: number
+  documentType: string | null
+  summaryShort: string | null
+  status: 'PENDING' | 'PROCESSING' | 'INDEXED' | 'FAILED'
+  tags: string[]
+  createdAt: string
+}
+
+export interface DocumentDetail extends Document {
+  summaryLong: string | null
+  updatedAt: string
+}
+
+export interface PageResponse<T> {
+  content: T[]
+  page: number
+  size: number
+  totalElements: number
+  totalPages: number
+}
+
+export interface SearchResult {
+  documentId: number
+  title: string
+  summaryShort: string | null
+  documentType: string | null
+  score: number
+  highlights: string[]
+}
+
+export interface SearchResponse {
+  results: SearchResult[]
+  total: number
+  query: string
+  mode: string
+}
+
+export interface QaResponse {
+  answer: string
+  sources: ChunkSource[]
+}
+
+export interface ChunkSource {
+  chunkId: number
+  pageFrom: number
+  pageTo: number
+  excerpt: string
+}
+
+export interface SimilarDocument {
+  documentId: number
+  title: string
+  summaryShort: string | null
+  similarity: number
+}
+
+export interface AdminStats {
+  totalDocuments: number
+  indexedDocuments: number
+  pendingDocuments: number
+  failedDocuments: number
+  indexingRate: number
+  totalQueries: number
+  avgLatencyMs: number
+}

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="max-w-6xl mx-auto px-4 py-6">
+    <h1 class="text-2xl font-bold text-slate-800 mb-6">관리자 대시보드</h1>
+
+    <div v-if="stats" class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+      <StatCard title="전체 문서" :value="stats.totalDocuments" icon="FileText" color="blue" />
+      <StatCard title="인덱싱 완료" :value="stats.indexedDocuments" icon="CheckCircle" color="green" />
+      <StatCard title="처리 실패" :value="stats.failedDocuments" icon="XCircle" color="red" />
+      <StatCard title="총 질문 수" :value="stats.totalQueries" icon="MessageSquare" color="purple" />
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div class="card p-6">
+        <h2 class="text-sm font-semibold text-slate-700 mb-4">인덱싱 성공률</h2>
+        <div class="flex items-center gap-4">
+          <div class="w-20 h-20 relative">
+            <svg class="transform -rotate-90 w-20 h-20">
+              <circle cx="40" cy="40" r="32" stroke="#e2e8f0" stroke-width="8" fill="none" />
+              <circle
+                cx="40" cy="40" r="32"
+                stroke="#3b82f6" stroke-width="8" fill="none"
+                :stroke-dasharray="`${(stats?.indexingRate || 0) * 2.01} 201`"
+              />
+            </svg>
+            <div class="absolute inset-0 flex items-center justify-center">
+              <span class="text-sm font-bold text-slate-700">{{ Math.round(stats?.indexingRate || 0) }}%</span>
+            </div>
+          </div>
+          <div class="text-sm text-slate-600 space-y-1">
+            <p>완료: <span class="font-medium text-slate-800">{{ stats?.indexedDocuments }}</span></p>
+            <p>대기: <span class="font-medium text-slate-800">{{ stats?.pendingDocuments }}</span></p>
+            <p>실패: <span class="font-medium text-red-600">{{ stats?.failedDocuments }}</span></p>
+          </div>
+        </div>
+      </div>
+
+      <div class="card p-6">
+        <h2 class="text-sm font-semibold text-slate-700 mb-4">AI 응답 성능</h2>
+        <div class="space-y-3">
+          <div class="flex justify-between text-sm">
+            <span class="text-slate-500">평균 응답 시간</span>
+            <span class="font-medium text-slate-800">{{ Math.round(stats?.avgLatencyMs || 0) }}ms</span>
+          </div>
+          <div class="flex justify-between text-sm">
+            <span class="text-slate-500">총 질문 수</span>
+            <span class="font-medium text-slate-800">{{ stats?.totalQueries }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card p-6 mt-6">
+      <h2 class="text-sm font-semibold text-slate-700 mb-4">처리 실패 문서</h2>
+      <div v-if="failedDocs.length === 0" class="text-sm text-slate-400">실패한 문서가 없습니다.</div>
+      <div v-else class="space-y-2">
+        <div
+          v-for="doc in failedDocs"
+          :key="doc.id"
+          class="flex items-center justify-between p-3 bg-red-50 rounded-lg"
+        >
+          <span class="text-sm text-slate-700">{{ doc.title }}</span>
+          <button @click="reprocess(doc.id)" class="btn-secondary text-xs px-2 py-1">
+            재처리
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { api } from '@/lib/api'
+import type { AdminStats, Document } from '@/types'
+import StatCard from '@/components/admin/StatCard.vue'
+
+const stats = ref<AdminStats | null>(null)
+const failedDocs = ref<Document[]>([])
+
+async function loadData() {
+  const [statsRes, failedRes] = await Promise.all([
+    api.get<AdminStats>('/admin/stats'),
+    api.get<Document[]>('/admin/failed-documents')
+  ])
+  stats.value = statsRes.data
+  failedDocs.value = failedRes.data
+}
+
+async function reprocess(id: number) {
+  await api.post(`/admin/documents/${id}/reprocess`)
+  await loadData()
+}
+
+onMounted(loadData)
+</script>

--- a/frontend/src/views/DocumentDetailView.vue
+++ b/frontend/src/views/DocumentDetailView.vue
@@ -1,0 +1,146 @@
+<template>
+  <div v-if="document" class="h-[calc(100vh-56px)] flex">
+    <div class="flex-1 min-w-0 border-r border-slate-200 flex flex-col">
+      <div class="flex items-center gap-2 px-4 py-2 bg-white border-b border-slate-200">
+        <RouterLink to="/" class="btn-secondary text-xs px-2 py-1">
+          <ChevronLeft class="w-3 h-3" />
+          목록
+        </RouterLink>
+        <span class="text-sm font-medium text-slate-700 truncate">{{ document.title }}</span>
+        <div class="ml-auto flex items-center gap-2">
+          <span class="text-xs text-slate-400">{{ document.pageCount }}페이지</span>
+          <a :href="`/api/documents/${document.id}/download`" class="btn-secondary text-xs px-2 py-1">
+            <Download class="w-3 h-3" />
+            다운로드
+          </a>
+        </div>
+      </div>
+      <PdfViewer :document-id="document.id" class="flex-1" />
+    </div>
+
+    <div class="w-96 flex flex-col overflow-hidden bg-white">
+      <div class="flex border-b border-slate-200 px-4">
+        <button
+          v-for="tab in tabs"
+          :key="tab.key"
+          @click="activeTab = tab.key"
+          :class="[
+            'py-3 px-2 text-sm font-medium border-b-2 -mb-px transition-colors',
+            activeTab === tab.key
+              ? 'border-primary-600 text-primary-700'
+              : 'border-transparent text-slate-500 hover:text-slate-700'
+          ]"
+        >
+          {{ tab.label }}
+        </button>
+      </div>
+
+      <div class="flex-1 overflow-y-auto p-4">
+        <div v-if="activeTab === 'meta'" class="space-y-4">
+          <div>
+            <p class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-1">제목</p>
+            <p class="text-sm text-slate-800 font-medium">{{ document.title }}</p>
+          </div>
+          <div v-if="document.description">
+            <p class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-1">설명</p>
+            <p class="text-sm text-slate-600">{{ document.description }}</p>
+          </div>
+          <div>
+            <p class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-1">정보</p>
+            <div class="space-y-1 text-sm text-slate-600">
+              <div class="flex justify-between">
+                <span>파일명</span>
+                <span class="text-slate-800 truncate max-w-48" :title="document.originalFileName">{{ document.originalFileName }}</span>
+              </div>
+              <div class="flex justify-between">
+                <span>페이지 수</span>
+                <span class="text-slate-800">{{ document.pageCount }}페이지</span>
+              </div>
+              <div class="flex justify-between">
+                <span>파일 크기</span>
+                <span class="text-slate-800">{{ formatSize(document.fileSize) }}</span>
+              </div>
+              <div class="flex justify-between">
+                <span>문서 유형</span>
+                <span class="text-slate-800">{{ document.documentType || '-' }}</span>
+              </div>
+              <div class="flex justify-between">
+                <span>상태</span>
+                <StatusBadge :status="document.status" />
+              </div>
+            </div>
+          </div>
+          <div v-if="document.tags.length > 0">
+            <p class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-2">태그</p>
+            <div class="flex flex-wrap gap-1">
+              <span
+                v-for="tag in document.tags"
+                :key="tag"
+                class="px-2 py-0.5 bg-primary-50 text-primary-700 rounded-full text-xs"
+              >{{ tag }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div v-if="activeTab === 'summary'" class="space-y-4">
+          <div v-if="document.summaryShort" class="p-3 bg-primary-50 rounded-lg">
+            <p class="text-xs font-medium text-primary-700 mb-1">3줄 요약</p>
+            <p class="text-sm text-slate-700 leading-relaxed">{{ document.summaryShort }}</p>
+          </div>
+          <div v-if="document.summaryLong">
+            <p class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-2">상세 요약</p>
+            <p class="text-sm text-slate-600 leading-relaxed whitespace-pre-line">{{ document.summaryLong }}</p>
+          </div>
+          <div v-if="!document.summaryShort && !document.summaryLong" class="text-center py-8 text-slate-400 text-sm">
+            요약이 아직 생성되지 않았습니다.
+          </div>
+        </div>
+
+        <div v-if="activeTab === 'qa'" class="flex flex-col h-full -m-4">
+          <QaPanel :document-id="document.id" />
+        </div>
+
+        <div v-if="activeTab === 'similar'">
+          <SimilarDocuments :document-id="document.id" />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div v-else class="flex items-center justify-center h-64">
+    <Loader2 class="w-8 h-8 animate-spin text-primary-500" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { ChevronLeft, Download, Loader2 } from 'lucide-vue-next'
+import { useDocumentStore } from '@/stores/document'
+import PdfViewer from '@/components/viewer/PdfViewer.vue'
+import QaPanel from '@/components/ai/QaPanel.vue'
+import SimilarDocuments from '@/components/ai/SimilarDocuments.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
+
+const route = useRoute()
+const store = useDocumentStore()
+const document = ref(store.currentDocument)
+
+const activeTab = ref('summary')
+const tabs = [
+  { key: 'summary', label: 'AI 요약' },
+  { key: 'qa', label: '질문응답' },
+  { key: 'similar', label: '유사 문서' },
+  { key: 'meta', label: '정보' },
+]
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+onMounted(async () => {
+  const id = Number(route.params.id)
+  document.value = await store.fetchDocument(id)
+})
+</script>

--- a/frontend/src/views/DocumentListView.vue
+++ b/frontend/src/views/DocumentListView.vue
@@ -1,0 +1,159 @@
+<template>
+  <div class="max-w-7xl mx-auto px-4 py-6">
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-2xl font-bold text-slate-800">문서</h1>
+        <p class="text-sm text-slate-500 mt-0.5">{{ store.total }}개의 문서</p>
+      </div>
+      <button @click="showUpload = true" class="btn-primary">
+        <Upload class="w-4 h-4" />
+        PDF 업로드
+      </button>
+    </div>
+
+    <div class="card p-4 mb-6">
+      <div class="flex gap-3">
+        <div class="flex-1 relative">
+          <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+          <input
+            v-model="searchQuery"
+            @input="debounceSearch"
+            type="text"
+            class="input pl-9"
+            placeholder="문서 제목, 내용으로 검색..."
+          />
+        </div>
+        <select v-model="searchMode" @change="doSearch" class="input w-36">
+          <option value="HYBRID">하이브리드</option>
+          <option value="KEYWORD">키워드</option>
+          <option value="SEMANTIC">의미 검색</option>
+          <option value="FUZZY">오타 허용</option>
+        </select>
+        <select v-model="docTypeFilter" @change="doSearch" class="input w-36">
+          <option value="">전체 유형</option>
+          <option value="계약서">계약서</option>
+          <option value="매뉴얼">매뉴얼</option>
+          <option value="제안서">제안서</option>
+          <option value="보고서">보고서</option>
+          <option value="정책문서">정책문서</option>
+        </select>
+      </div>
+    </div>
+
+    <div v-if="store.loading" class="flex justify-center py-20">
+      <Loader2 class="w-8 h-8 animate-spin text-primary-500" />
+    </div>
+
+    <div v-else-if="displayDocuments.length === 0" class="card p-16 text-center">
+      <FileText class="w-12 h-12 text-slate-300 mx-auto mb-3" />
+      <p class="text-slate-500">문서가 없습니다. PDF를 업로드해주세요.</p>
+    </div>
+
+    <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <DocumentCard
+        v-for="doc in displayDocuments"
+        :key="doc.id"
+        :document="doc"
+        @click="router.push(`/documents/${doc.id}`)"
+        @delete="handleDelete(doc.id)"
+      />
+    </div>
+
+    <div v-if="!isSearchMode && store.totalPages > 1" class="flex justify-center mt-8 gap-2">
+      <button
+        v-for="p in store.totalPages"
+        :key="p"
+        @click="goPage(p - 1)"
+        :class="[
+          'w-8 h-8 rounded-lg text-sm font-medium transition-colors',
+          currentPage === p - 1
+            ? 'bg-primary-600 text-white'
+            : 'bg-white text-slate-600 hover:bg-surface-100 border border-slate-200'
+        ]"
+      >
+        {{ p }}
+      </button>
+    </div>
+
+    <UploadModal v-if="showUpload" @close="showUpload = false" @success="onUploadSuccess" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { Search, Upload, FileText, Loader2 } from 'lucide-vue-next'
+import { useDocumentStore } from '@/stores/document'
+import { api } from '@/lib/api'
+import type { SearchResult } from '@/types'
+import DocumentCard from '@/components/document/DocumentCard.vue'
+import UploadModal from '@/components/document/UploadModal.vue'
+
+const router = useRouter()
+const store = useDocumentStore()
+
+const showUpload = ref(false)
+const searchQuery = ref('')
+const searchMode = ref('HYBRID')
+const docTypeFilter = ref('')
+const currentPage = ref(0)
+const searchResults = ref<SearchResult[]>([])
+const isSearchMode = ref(false)
+
+let debounceTimer: ReturnType<typeof setTimeout>
+
+function debounceSearch() {
+  clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(doSearch, 400)
+}
+
+async function doSearch() {
+  if (searchQuery.value.trim()) {
+    isSearchMode.value = true
+    const res = await api.get('/search', {
+      params: { query: searchQuery.value, mode: searchMode.value, docType: docTypeFilter.value || undefined }
+    })
+    searchResults.value = res.data.results
+  } else {
+    isSearchMode.value = false
+    store.fetchDocuments({ docType: docTypeFilter.value || undefined, page: currentPage.value })
+  }
+}
+
+const displayDocuments = computed(() => {
+  if (isSearchMode.value) {
+    return searchResults.value.map(r => ({
+      id: r.documentId,
+      title: r.title,
+      description: null,
+      originalFileName: '',
+      pageCount: 0,
+      fileSize: 0,
+      documentType: r.documentType,
+      summaryShort: r.summaryShort,
+      status: 'INDEXED' as const,
+      tags: [],
+      createdAt: ''
+    }))
+  }
+  return store.documents
+})
+
+async function handleDelete(id: number) {
+  if (confirm('문서를 삭제하시겠습니까?')) {
+    await store.deleteDocument(id)
+  }
+}
+
+function goPage(page: number) {
+  currentPage.value = page
+  store.fetchDocuments({ page, docType: docTypeFilter.value || undefined })
+}
+
+function onUploadSuccess() {
+  showUpload.value = false
+  store.fetchDocuments()
+}
+
+onMounted(() => store.fetchDocuments())
+</script>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary-50 to-slate-100">
+    <div class="card p-8 w-full max-w-md">
+      <div class="text-center mb-8">
+        <div class="inline-flex items-center justify-center w-12 h-12 bg-primary-600 rounded-xl mb-4">
+          <FileText class="w-6 h-6 text-white" />
+        </div>
+        <h1 class="text-2xl font-bold text-slate-800">PaperLens AI</h1>
+        <p class="text-sm text-slate-500 mt-1">AI 문서 지식 플랫폼</p>
+      </div>
+
+      <form @submit.prevent="handleLogin" class="space-y-4">
+        <div>
+          <label class="block text-sm font-medium text-slate-700 mb-1">이메일</label>
+          <input
+            v-model="form.email"
+            type="email"
+            class="input"
+            placeholder="admin@paperlens.com"
+            required
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-slate-700 mb-1">비밀번호</label>
+          <input
+            v-model="form.password"
+            type="password"
+            class="input"
+            placeholder="••••••••"
+            required
+          />
+        </div>
+
+        <div v-if="error" class="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">
+          {{ error }}
+        </div>
+
+        <button type="submit" class="btn-primary w-full justify-center" :disabled="loading">
+          <Loader2 v-if="loading" class="w-4 h-4 animate-spin" />
+          {{ loading ? '로그인 중...' : '로그인' }}
+        </button>
+      </form>
+
+      <div class="mt-6 p-3 bg-surface-50 rounded-lg text-xs text-slate-500">
+        <p class="font-medium mb-1">데모 계정</p>
+        <p>admin@paperlens.com / admin123</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { FileText, Loader2 } from 'lucide-vue-next'
+import { useAuthStore } from '@/stores/auth'
+
+const router = useRouter()
+const auth = useAuthStore()
+
+const form = ref({ email: 'admin@paperlens.com', password: 'admin123' })
+const loading = ref(false)
+const error = ref('')
+
+async function handleLogin() {
+  loading.value = true
+  error.value = ''
+  try {
+    await auth.login(form.value.email, form.value.password)
+    router.push('/')
+  } catch {
+    error.value = '이메일 또는 비밀번호가 올바르지 않습니다.'
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,28 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{vue,js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: '#eff6ff',
+          100: '#dbeafe',
+          500: '#3b82f6',
+          600: '#2563eb',
+          700: '#1d4ed8',
+        },
+        surface: {
+          50: '#f8fafc',
+          100: '#f1f5f9',
+          200: '#e2e8f0',
+          800: '#1e293b',
+          900: '#0f172a',
+        }
+      }
+    },
+  },
+  plugins: [],
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2023",
+    "useDefineForClassFields": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "noEmit": true,
+    "types": ["vite/client"],
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["env.d.ts", "src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
+  },
+})


### PR DESCRIPTION
## 내용

- `frontend/` 디렉터리에 Vue 3 + Vite 기반의 실제 서비스용 SPA 프론트엔드를 추가했습니다.
  - 로그인, 문서 목록/상세, 관리자 화면 등 PaperLens 워크플로우를 반영한 라우팅/레이아웃 구성
  - Pinia 스토어, 공통 컴포넌트, PDF 뷰어, AI 패널 등 기본 UI 레이어 구현
- `README.md`를 업데이트해 프로젝트 기능, 아키텍처, 디렉터리 구조를 현재 상태에 맞게 정리했습니다.
  - `frontend/`와 `docs/frontend/` 역할을 구분
  - 백엔드 패키지 구조(웹/퍼시스턴스/어댑터/검색) 개요 추가

## 변경 범위

- README 문서 변경
- `frontend` 신규 프로젝트 추가 (기존 `docs/frontend`는 문서/데모 용도로 유지)

## 테스트

- [x] `frontend`에서 `pnpm install` 또는 `npm install` 실행
- [x] `pnpm dev` / `npm run dev`로 로컬에서 주요 플로우(로그인 → 문서 목록 → 상세 → 관리자) 확인