### PR TITLE
feat: complete upload tagging flow and stabilize document detail loading

### DIFF
--- a/frontend/src/components/document/UploadModal.vue
+++ b/frontend/src/components/document/UploadModal.vue
@@ -1,59 +1,91 @@
 <template>
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40" @click.self="$emit('close')">
-    <div class="card w-full max-w-lg p-6 mx-4">
-      <div class="flex items-center justify-between mb-6">
-        <h2 class="text-lg font-bold text-slate-800">PDF 업로드</h2>
-        <button @click="$emit('close')" class="p-1 hover:bg-surface-100 rounded">
-          <X class="w-5 h-5 text-slate-400" />
+    <div class="card mx-4 w-full max-w-lg p-6">
+      <div class="mb-6 flex items-center justify-between">
+        <h2 class="text-lg font-bold text-slate-800">Upload PDF</h2>
+        <button type="button" class="rounded p-1 hover:bg-surface-100" @click="$emit('close')">
+          <X class="h-5 w-5 text-slate-400" />
         </button>
       </div>
 
-      <form @submit.prevent="handleUpload" class="space-y-4">
+      <form class="space-y-4" @submit.prevent="handleUpload">
         <div
           @dragover.prevent
           @drop.prevent="handleDrop"
           @click="fileInput?.click()"
           :class="[
-            'border-2 border-dashed rounded-xl p-8 text-center cursor-pointer transition-colors',
+            'cursor-pointer rounded-xl border-2 border-dashed p-8 text-center transition-colors',
             file ? 'border-primary-300 bg-primary-50' : 'border-slate-200 hover:border-primary-300 hover:bg-surface-50'
           ]"
         >
           <input ref="fileInput" type="file" accept=".pdf" class="hidden" @change="handleFileChange" />
-          <FileText class="w-10 h-10 text-slate-300 mx-auto mb-2" />
+          <FileText class="mx-auto mb-2 h-10 w-10 text-slate-300" />
           <p v-if="file" class="text-sm font-medium text-primary-700">{{ file.name }}</p>
-          <p v-else class="text-sm text-slate-500">
-            PDF 파일을 드래그하거나 클릭하여 선택
+          <p v-else class="text-sm text-slate-500">Drag a PDF here or click to choose a file.</p>
+          <p class="mt-1 text-xs text-slate-400">Up to 100MB</p>
+        </div>
+
+        <div>
+          <label class="mb-1 block text-sm font-medium text-slate-700">
+            Title <span class="text-red-500">*</span>
+          </label>
+          <input v-model="title" type="text" class="input" placeholder="Document title" required />
+        </div>
+
+        <div>
+          <label class="mb-1 block text-sm font-medium text-slate-700">Description</label>
+          <textarea
+            v-model="description"
+            class="input resize-none"
+            rows="2"
+            placeholder="Document description (optional)"
+          />
+        </div>
+
+        <div>
+          <label class="mb-1 block text-sm font-medium text-slate-700">Tags</label>
+          <input
+            v-model="tagInput"
+            type="text"
+            class="input"
+            placeholder="Example: HR, policy, onboarding"
+            @blur="commitTagInput"
+            @keydown="handleTagKeydown"
+          />
+          <p class="mt-1 text-xs text-slate-400">
+            Press Enter or type a comma to add a tag. # and commas are removed automatically.
           </p>
-          <p class="text-xs text-slate-400 mt-1">최대 100MB</p>
-        </div>
-
-        <div>
-          <label class="block text-sm font-medium text-slate-700 mb-1">제목 <span class="text-red-500">*</span></label>
-          <input v-model="title" type="text" class="input" placeholder="문서 제목" required />
-        </div>
-
-        <div>
-          <label class="block text-sm font-medium text-slate-700 mb-1">설명</label>
-          <textarea v-model="description" class="input resize-none" rows="2" placeholder="문서 설명 (선택)" />
+          <div v-if="tags.length > 0" class="mt-2 flex flex-wrap gap-1">
+            <span
+              v-for="tag in tags"
+              :key="tag"
+              class="inline-flex items-center gap-1 rounded-full bg-primary-50 px-2 py-0.5 text-xs text-primary-700"
+            >
+              {{ tag }}
+              <button type="button" class="rounded hover:bg-primary-100" @click="removeTag(tag)">
+                <X class="h-3 w-3" />
+              </button>
+            </span>
+          </div>
         </div>
 
         <div v-if="uploading" class="space-y-1">
           <div class="flex justify-between text-xs text-slate-500">
-            <span>업로드 중...</span>
+            <span>Uploading...</span>
             <span>{{ progress }}%</span>
           </div>
-          <div class="h-1.5 bg-surface-200 rounded-full overflow-hidden">
+          <div class="h-1.5 overflow-hidden rounded-full bg-surface-200">
             <div class="h-full bg-primary-500 transition-all" :style="{ width: `${progress}%` }" />
           </div>
         </div>
 
-        <div v-if="error" class="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">{{ error }}</div>
+        <div v-if="error" class="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{{ error }}</div>
 
-        <div class="flex gap-3 justify-end">
-          <button type="button" @click="$emit('close')" class="btn-secondary">취소</button>
+        <div class="flex justify-end gap-3">
+          <button type="button" class="btn-secondary" @click="$emit('close')">Cancel</button>
           <button type="submit" class="btn-primary" :disabled="!file || !title || uploading">
-            <Loader2 v-if="uploading" class="w-4 h-4 animate-spin" />
-            {{ uploading ? '업로드 중...' : '업로드' }}
+            <Loader2 v-if="uploading" class="h-4 w-4 animate-spin" />
+            {{ uploading ? 'Uploading...' : 'Upload' }}
           </button>
         </div>
       </form>
@@ -62,8 +94,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import { FileText, X, Loader2 } from 'lucide-vue-next'
+import { computed, ref } from 'vue'
+import { FileText, Loader2, X } from 'lucide-vue-next'
 import { useDocumentStore } from '@/stores/document'
 
 const emit = defineEmits<{ close: []; success: [] }>()
@@ -73,38 +105,98 @@ const fileInput = ref<HTMLInputElement>()
 const file = ref<File | null>(null)
 const title = ref('')
 const description = ref('')
+const tagInput = ref('')
+const tags = ref<string[]>([])
 const uploading = ref(false)
 const progress = ref(0)
 const error = ref('')
 
+const maxTags = 8
+
+const canAddMoreTags = computed(() => tags.value.length < maxTags)
+
+function sanitizeTagParts(value: string): string[] {
+  return value
+    .split(/[,\n\r，]+/)
+    .map((entry) => entry.replace(/#/g, ' ').replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+}
+
+function appendTags(values: string[]) {
+  if (values.length === 0 || !canAddMoreTags.value) return
+
+  const seen = new Set(tags.value.map((entry) => entry.toLowerCase()))
+  const nextTags = [...tags.value]
+
+  for (const value of values) {
+    const normalizedKey = value.toLowerCase()
+    if (seen.has(normalizedKey)) continue
+    nextTags.push(value)
+    seen.add(normalizedKey)
+    if (nextTags.length >= maxTags) break
+  }
+
+  tags.value = nextTags
+}
+
+function commitTagInput() {
+  appendTags(sanitizeTagParts(tagInput.value))
+  tagInput.value = ''
+}
+
+function removeTag(tag: string) {
+  tags.value = tags.value.filter((entry) => entry !== tag)
+}
+
+function handleTagKeydown(event: KeyboardEvent) {
+  if (event.key === 'Enter' || event.key === ',') {
+    event.preventDefault()
+    commitTagInput()
+  }
+}
+
 function handleFileChange(e: Event) {
-  const f = (e.target as HTMLInputElement).files?.[0]
-  if (f) { file.value = f; if (!title.value) title.value = f.name.replace('.pdf', '') }
+  const selectedFile = (e.target as HTMLInputElement).files?.[0]
+  if (!selectedFile) return
+
+  file.value = selectedFile
+  if (!title.value) {
+    title.value = selectedFile.name.replace(/\.pdf$/i, '')
+  }
 }
 
 function handleDrop(e: DragEvent) {
-  const f = e.dataTransfer?.files[0]
-  if (f?.type === 'application/pdf') { file.value = f; if (!title.value) title.value = f.name.replace('.pdf', '') }
+  const droppedFile = e.dataTransfer?.files[0]
+  if (!droppedFile || droppedFile.type !== 'application/pdf') return
+
+  file.value = droppedFile
+  if (!title.value) {
+    title.value = droppedFile.name.replace(/\.pdf$/i, '')
+  }
 }
 
 async function handleUpload() {
   if (!file.value) return
+
   uploading.value = true
   error.value = ''
   progress.value = 10
 
   try {
+    commitTagInput()
+
     const formData = new FormData()
     formData.append('file', file.value)
     formData.append('title', title.value)
-    if (description.value) formData.append('description', description.value)
+    if (description.value.trim()) formData.append('description', description.value.trim())
+    tags.value.forEach((tag) => formData.append('tags', tag))
 
     progress.value = 50
     await store.uploadDocument(formData)
     progress.value = 100
     emit('success')
   } catch {
-    error.value = '업로드에 실패했습니다. 다시 시도해주세요.'
+    error.value = 'Upload failed. Please try again.'
   } finally {
     uploading.value = false
   }

--- a/frontend/src/stores/document.ts
+++ b/frontend/src/stores/document.ts
@@ -47,9 +47,7 @@ export const useDocumentStore = defineStore('document', () => {
   }
 
   async function uploadDocument(formData: FormData) {
-    const res = await api.post<Document>('/documents/upload', formData, {
-      headers: { 'Content-Type': 'multipart/form-data' }
-    })
+    const res = await api.post<Document>('/documents/upload', formData)
     await fetchDocuments()
     return res.data
   }

--- a/frontend/src/views/DocumentDetailView.vue
+++ b/frontend/src/views/DocumentDetailView.vue
@@ -110,6 +110,12 @@
       </div>
     </div>
   </div>
+  <div v-else-if="errorMessage" class="flex h-64 items-center justify-center px-6 text-center">
+    <div>
+      <p class="text-sm font-medium text-red-600">{{ errorMessage }}</p>
+      <p class="mt-2 text-xs text-slate-400">Try refreshing the page after restarting the backend server.</p>
+    </div>
+  </div>
   <div v-else class="flex items-center justify-center h-64">
     <Loader2 class="w-8 h-8 animate-spin text-primary-500" />
   </div>
@@ -129,6 +135,7 @@ import StatusBadge from '@/components/common/StatusBadge.vue'
 const route = useRoute()
 const store = useDocumentStore()
 const document = ref<DocumentDetail | null>(store.currentDocument)
+const errorMessage = ref('')
 
 const activeTab = ref('summary')
 const tabs = [
@@ -160,6 +167,22 @@ function clearRefreshTimer() {
   refreshTimer = null
 }
 
+async function loadDocument(id: number) {
+  clearRefreshTimer()
+  errorMessage.value = ''
+
+  try {
+    document.value = await store.fetchDocument(id)
+    scheduleRefresh()
+  } catch (error: any) {
+    document.value = null
+    const serverMessage = error.response?.data?.message
+    errorMessage.value = typeof serverMessage === 'string'
+      ? serverMessage
+      : 'Failed to load this document.'
+  }
+}
+
 function scheduleRefresh() {
   clearRefreshTimer()
   if (!shouldRefreshDocument(document.value) || refreshAttempts >= 15) return
@@ -167,16 +190,14 @@ function scheduleRefresh() {
   refreshTimer = setTimeout(async () => {
     const id = Number(route.params.id)
     refreshAttempts += 1
-    document.value = await store.fetchDocument(id)
-    scheduleRefresh()
+    await loadDocument(id)
   }, 2000)
 }
 
 onMounted(async () => {
   const id = Number(route.params.id)
   refreshAttempts = 0
-  document.value = await store.fetchDocument(id)
-  scheduleRefresh()
+  await loadDocument(id)
 })
 
 watch(
@@ -185,8 +206,7 @@ watch(
     const id = Number(nextId)
     if (!id || Number.isNaN(id)) return
     refreshAttempts = 0
-    document.value = await store.fetchDocument(id)
-    scheduleRefresh()
+    await loadDocument(id)
   },
 )
 

--- a/paperlens/paperlens-application/src/main/kotlin/com/sleekydz86/paperlens/application/support/DocumentTagSupport.kt
+++ b/paperlens/paperlens-application/src/main/kotlin/com/sleekydz86/paperlens/application/support/DocumentTagSupport.kt
@@ -1,0 +1,37 @@
+package com.sleekydz86.paperlens.application.support
+
+object DocumentTagSupport {
+
+    private const val MAX_TAGS = 8
+    private val whitespaceRegex = Regex("\\s+")
+    private val separatorRegex = Regex("[,\n\r，]+")
+
+    fun normalize(tags: List<String>): List<String> {
+        val seen = linkedSetOf<String>()
+        val normalized = mutableListOf<String>()
+
+        tags.asSequence()
+            .flatMap { separatorRegex.split(it).asSequence() }
+            .map { sanitize(it) }
+            .filter { it.isNotEmpty() }
+            .forEach { tag ->
+                val key = tag.lowercase()
+                if (seen.add(key)) {
+                    normalized += tag
+                }
+            }
+
+        return normalized.take(MAX_TAGS)
+    }
+
+    fun resolve(manualTags: List<String>, suggestedKeywords: List<String>): List<String> {
+        val normalizedManualTags = normalize(manualTags)
+        if (normalizedManualTags.isNotEmpty()) return normalizedManualTags
+        return normalize(suggestedKeywords)
+    }
+
+    private fun sanitize(raw: String): String =
+        raw.replace("#", " ")
+            .replace(whitespaceRegex, " ")
+            .trim()
+}

--- a/paperlens/paperlens-application/src/main/kotlin/com/sleekydz86/paperlens/application/usecase/DocumentUseCase.kt
+++ b/paperlens/paperlens-application/src/main/kotlin/com/sleekydz86/paperlens/application/usecase/DocumentUseCase.kt
@@ -9,6 +9,7 @@ import com.sleekydz86.paperlens.application.port.DocumentJobPort
 import com.sleekydz86.paperlens.application.port.DocumentProcessPort
 import com.sleekydz86.paperlens.application.port.FileStoragePort
 import com.sleekydz86.paperlens.application.port.PdfPort
+import com.sleekydz86.paperlens.application.support.DocumentTagSupport
 import com.sleekydz86.paperlens.domain.document.Document
 import com.sleekydz86.paperlens.domain.document.DocumentStatus
 import com.sleekydz86.paperlens.domain.job.DocumentJobType
@@ -37,6 +38,7 @@ open class DocumentUseCase(
         title: String,
         description: String?,
         userId: Long,
+        tagNames: List<String> = emptyList(),
     ): DocumentResponse {
         val pageCount = pdfPort.getPageCount(fileBytes)
         if (pageCount <= 0) {
@@ -44,6 +46,7 @@ open class DocumentUseCase(
         }
         val fileName = "${UUID.randomUUID()}_$originalFileName"
         val storagePath = fileStorage.save(fileBytes, fileName)
+        val normalizedTags = DocumentTagSupport.normalize(tagNames)
 
         val document = Document(
             id = 0L,
@@ -62,7 +65,7 @@ open class DocumentUseCase(
             createdAt = LocalDateTime.now(),
             updatedAt = LocalDateTime.now(),
             deletedAt = null,
-            tagNames = emptyList(),
+            tagNames = normalizedTags,
         )
         val saved = documentRepository.save(document)
         enqueueProcessingJobs(saved.id)
@@ -89,7 +92,7 @@ open class DocumentUseCase(
     open fun getDocument(id: Long): DocumentDetailResponse {
         val document = documentRepository.findById(id)
             ?: throw NoSuchElementException("臾몄꽌瑜?李얠쓣 ???놁뒿?덈떎: $id")
-        return ensureSummary(document).toDetailResponse()
+        return ensureDocumentMetadata(document).toDetailResponse()
     }
 
     @Transactional
@@ -99,7 +102,7 @@ open class DocumentUseCase(
         val updated = document.copy(
             title = request.title ?: document.title,
             description = request.description ?: document.description,
-            tagNames = request.tags ?: document.tagNames,
+            tagNames = request.tags?.let(DocumentTagSupport::normalize) ?: document.tagNames,
             updatedAt = LocalDateTime.now(),
         )
         return documentRepository.save(updated).toDetailResponse()
@@ -142,20 +145,35 @@ open class DocumentUseCase(
         }
     }
 
-    private fun ensureSummary(document: Document): Document {
+    private fun ensureDocumentMetadata(document: Document): Document {
         val needsSummary = document.summaryShort.isNullOrBlank() || document.summaryLong.isNullOrBlank()
         val needsDocType = document.documentType.isNullOrBlank()
-        if (!needsSummary && !needsDocType) return document
+        val needsTags = document.tagNames.isEmpty()
+        if (!needsSummary && !needsDocType && !needsTags) return document
 
         val chunks = chunkRepository.findByDocumentIdOrderByChunkIndex(document.id)
         val combinedText = chunks.joinToString("\n") { it.content }.trim()
         if (combinedText.isBlank()) return document
 
-        val summary = aiPort.summarizeText(combinedText)
+        val summary = if (needsSummary || needsTags) aiPort.summarizeText(combinedText) else null
         val documentType = if (needsDocType) aiPort.classifyDocumentType(combinedText) else document.documentType
-        return documentRepository.save(
-            document.withSummaries(summary.short, summary.long, documentType)
-        )
+        var updated = document
+
+        if (needsSummary || needsDocType) {
+            updated = updated.withSummaries(
+                short = if (needsSummary) summary?.short else updated.summaryShort,
+                long = if (needsSummary) summary?.long else updated.summaryLong,
+                docType = documentType,
+            )
+        }
+
+        if (needsTags) {
+            updated = updated.withTags(
+                DocumentTagSupport.resolve(document.tagNames, summary?.keywords.orEmpty())
+            )
+        }
+
+        return if (updated == document) document else documentRepository.save(updated)
     }
 
     private fun Document.toResponse() = DocumentResponse(

--- a/paperlens/paperlens-infrastructure/src/main/kotlin/com/sleekydz86/paperlens/infrastructure/global/adapter/DocumentProcessAdapter.kt
+++ b/paperlens/paperlens-infrastructure/src/main/kotlin/com/sleekydz86/paperlens/infrastructure/global/adapter/DocumentProcessAdapter.kt
@@ -5,6 +5,7 @@ import com.sleekydz86.paperlens.application.port.DocumentJobPort
 import com.sleekydz86.paperlens.application.port.DocumentProcessPort
 import com.sleekydz86.paperlens.application.port.EmbeddingPort
 import com.sleekydz86.paperlens.application.port.FileStoragePort
+import com.sleekydz86.paperlens.application.support.DocumentTagSupport
 import com.sleekydz86.paperlens.domain.document.DocumentChunk
 import com.sleekydz86.paperlens.domain.document.DocumentStatus
 import com.sleekydz86.paperlens.domain.job.DocumentJobType
@@ -49,11 +50,11 @@ class DocumentProcessAdapter(
             val allText = savedChunks.joinToString("\n") { it.content }
             val summaryResult = runTrackedJob(documentId, DocumentJobType.SUMMARY) {
                 if (allText.isBlank()) {
-                    SummaryResult(short = null, long = null, documentType = null)
+                    SummaryResult(short = null, long = null, documentType = null, keywords = emptyList())
                 } else {
                     val summary = aiPort.summarizeText(allText)
                     val docType = aiPort.classifyDocumentType(allText)
-                    SummaryResult(summary.short, summary.long, docType)
+                    SummaryResult(summary.short, summary.long, docType, summary.keywords)
                 }
             }
 
@@ -64,9 +65,11 @@ class DocumentProcessAdapter(
                 }
             }
 
+            val resolvedTags = DocumentTagSupport.resolve(document.tagNames, summaryResult.keywords)
             documentRepository.save(
                 document.withStatus(DocumentStatus.INDEXED)
                     .withSummaries(summaryResult.short, summaryResult.long, summaryResult.documentType)
+                    .withTags(resolvedTags)
             )
         } catch (e: Exception) {
             logger.error("Document processing failed: documentId={}", documentId, e)
@@ -145,5 +148,6 @@ class DocumentProcessAdapter(
         val short: String?,
         val long: String?,
         val documentType: String?,
+        val keywords: List<String>,
     )
 }

--- a/paperlens/paperlens-infrastructure/src/main/kotlin/com/sleekydz86/paperlens/infrastructure/persistence/adapter/DocumentChunkRepositoryAdapter.kt
+++ b/paperlens/paperlens-infrastructure/src/main/kotlin/com/sleekydz86/paperlens/infrastructure/persistence/adapter/DocumentChunkRepositoryAdapter.kt
@@ -8,6 +8,8 @@ import com.sleekydz86.paperlens.infrastructure.persistence.repository.DocumentJp
 import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.sql.Timestamp
+import java.time.LocalDateTime
 
 @Component
 class DocumentChunkRepositoryAdapter(
@@ -32,7 +34,17 @@ class DocumentChunkRepositoryAdapter(
     }
 
     override fun findByDocumentIdOrderByChunkIndex(documentId: Long): List<DocumentChunk> =
-        chunkJpaRepository.findByDocumentIdOrderByChunkIndex(documentId).map { DocumentChunkMapper.toDomain(it) }
+        entityManager.createNativeQuery(
+            """
+            SELECT id, document_id, page_from, page_to, chunk_index, content, token_count, created_at
+            FROM document_chunks
+            WHERE document_id = ?
+            ORDER BY chunk_index
+            """.trimIndent()
+        )
+            .setParameter(1, documentId)
+            .resultList
+            .map { row -> toDomainChunk(row as Array<*>) }
 
     override fun deleteByDocumentId(documentId: Long) {
         chunkJpaRepository.deleteByDocumentId(documentId)
@@ -52,4 +64,24 @@ class DocumentChunkRepositoryAdapter(
             .setParameter(2, chunkId)
             .executeUpdate()
     }
+
+    private fun toDomainChunk(row: Array<*>): DocumentChunk =
+        DocumentChunk(
+            id = (row[0] as Number).toLong(),
+            documentId = (row[1] as Number).toLong(),
+            pageFrom = (row[2] as Number).toInt(),
+            pageTo = (row[3] as Number).toInt(),
+            chunkIndex = (row[4] as Number).toInt(),
+            content = row[5] as String,
+            tokenCount = (row[6] as Number).toInt(),
+            embedding = null,
+            createdAt = toLocalDateTime(row[7]),
+        )
+
+    private fun toLocalDateTime(value: Any?): LocalDateTime =
+        when (value) {
+            is LocalDateTime -> value
+            is Timestamp -> value.toLocalDateTime()
+            else -> LocalDateTime.now()
+        }
 }

--- a/paperlens/paperlens-infrastructure/src/main/kotlin/com/sleekydz86/paperlens/infrastructure/web/DocumentController.kt
+++ b/paperlens/paperlens-infrastructure/src/main/kotlin/com/sleekydz86/paperlens/infrastructure/web/DocumentController.kt
@@ -31,9 +31,11 @@ class DocumentController(
 
     @PostMapping("/upload", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun upload(
-        @RequestPart file: MultipartFile,
-        @RequestPart title: String,
-        @RequestPart(required = false) description: String?,
+        @RequestParam file: MultipartFile,
+        @RequestParam title: String,
+        @RequestParam(required = false) description: String?,
+        @RequestParam(required = false) tags: List<String>?,
+        @RequestParam(name = "tag", required = false) tag: List<String>?,
         @AuthenticationPrincipal user: UserEntity,
     ): ResponseEntity<Any> {
         val response = documentUseCase.uploadDocument(
@@ -42,6 +44,7 @@ class DocumentController(
             title = title,
             description = description,
             userId = user.id,
+            tagNames = normalizeTagParams(tags, tag),
         )
         redisCacheService.evictDocumentCaches()
         return ResponseEntity.ok(response)
@@ -78,6 +81,7 @@ class DocumentController(
     fun get(@PathVariable id: Long): ResponseEntity<Any> {
         redisCacheService.getDocumentDetail(id)?.let { return ResponseEntity.ok(it) }
         val response = documentUseCase.getDocument(id)
+        redisCacheService.evictDocumentCaches()
         redisCacheService.putDocumentDetail(id, response)
         return ResponseEntity.ok(response)
     }


### PR DESCRIPTION
## Summary
This PR completes the document tagging flow from upload to filtering, and fixes document detail failures caused by chunk loading and upload request parsing.

## What changed
- add tag input UI to the upload modal
- prevent Enter/comma in the tag field from triggering upload
- sanitize tag input on both frontend and backend
- persist uploaded tags into `document_tags`
- auto-generate tags from extracted document text when no tags are provided
- backfill missing metadata when opening existing document detail pages
- avoid loading chunk embeddings in the document detail path to prevent deserialization failures
- relax multipart upload parameter handling to fix unsupported media type errors
- improve document detail error handling in the frontend

## Why
- tag filtering was implemented, but real tag data was not being created during upload
- existing documents without tags needed a recovery path
- some document detail requests failed because old embedding values could not be deserialized
- upload requests could fail depending on multipart field handling

## Verification
- `:paperlens-infrastructure:compileKotlin` passed
- upload flow now accepts tags and stores them
- empty-tag uploads can be auto-tagged during indexing
- existing document detail pages no longer need to read embedding values to render metadata
